### PR TITLE
[codex] Release workflow hardening for Homebrew/AUR secret handling

### DIFF
--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
+      aur_configured: ${{ steps.aur.outputs.configured }}
     steps:
       - name: Resolve version/tag
         id: resolve
@@ -44,10 +45,23 @@ jobs:
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - name: Detect AUR configuration
+        id: aur
+        shell: bash
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish:
     name: Publish AUR
     needs: prepare
-    if: ${{ secrets.AUR_SSH_PRIVATE_KEY != '' }}
+    if: ${{ needs.prepare.outputs.aur_configured == 'true' }}
     runs-on: ubuntu-latest
     env:
       AUR_PACKAGE_NAME: ${{ vars.AUR_PACKAGE_NAME }}
@@ -109,7 +123,7 @@ jobs:
   not-configured:
     name: AUR Not Configured
     needs: prepare
-    if: ${{ secrets.AUR_SSH_PRIVATE_KEY == '' }}
+    if: ${{ needs.prepare.outputs.aur_configured != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Explain setup requirement

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -73,10 +73,28 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Compute goreleaser args
+        if: steps.prepare.outputs.release_exists == 'false'
+        id: goreleaser_args
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          args="release --clean"
+
+          if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+            args="$args --skip=homebrew"
+            echo "HOMEBREW_TAP_GITHUB_TOKEN is not set; skipping Homebrew publish."
+          fi
+
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
       - uses: goreleaser/goreleaser-action@v6
         if: steps.prepare.outputs.release_exists == 'false'
         with:
           version: "~> v2"
-          args: release --clean
+          args: ${{ steps.goreleaser_args.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,7 @@ brews:
   - repository:
       owner: dwellir-public
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://dwellir.com"
     description: "Dwellir CLI — Blockchain RPC infrastructure from your terminal"
     license: "MIT"


### PR DESCRIPTION
## Summary
Hotfixes release automation after PR #3 merge.

## Problems fixed
1. `Tag Release` failed on `main` because GoReleaser attempted to push Homebrew formula to `dwellir-public/homebrew-tap` using default `GITHUB_TOKEN`, which does not have cross-repo write access (403).
2. `AUR Release` workflow produced noisy failed checks due `secrets.*` being used directly in job-level `if` expressions.

## Changes
- `.github/workflows/tag-release.yml`
  - Compute GoReleaser args dynamically.
  - If `HOMEBREW_TAP_GITHUB_TOKEN` is missing, run with `--skip=homebrew` so release still succeeds.
  - If token is present, Homebrew publishing remains enabled.
- `.goreleaser.yaml`
  - Set Homebrew tap repository token to `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}`.
- `.github/workflows/aur-release.yml`
  - Detect AUR secret in `prepare` step and expose `aur_configured` output.
  - Gate publish/no-op jobs using `needs.prepare.outputs.aur_configured` instead of `secrets.*` in job-level `if`.

## Validation
- `go test ./...`
- Confirmed prior failure root-cause from run logs (`Tag Release` run 22453821395).

## Expected behavior
- Releases on `main` do not fail when Homebrew tap token is not configured.
- Homebrew publish works automatically once `HOMEBREW_TAP_GITHUB_TOKEN` is set.
- AUR workflow no longer emits invalid/noisy failed checks on push.
