### PR TITLE
[codex] Rename AUR package to dwellir-cli-bin

### DIFF
--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          package_name="${AUR_PACKAGE_NAME:-dwellir-bin}"
+          package_name="${AUR_PACKAGE_NAME:-dwellir-cli-bin}"
           repo_url="ssh://aur@aur.archlinux.org/${package_name}.git"
 
           rm -rf /tmp/aur-repo
@@ -117,7 +117,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add PKGBUILD .SRCINFO
-          git commit -m "dwellir-bin: update to ${{ needs.prepare.outputs.version }}-1"
+          git commit -m "${package_name}: update to ${{ needs.prepare.outputs.version }}-1"
           git push origin master
 
   not-configured:

--- a/docs/aur-setup.md
+++ b/docs/aur-setup.md
@@ -1,11 +1,11 @@
 # AUR Automation Setup (Safe)
 
-This guide prepares automatic AUR publishing for `dwellir-bin` from GitHub Actions.
+This guide prepares automatic AUR publishing for `dwellir-cli-bin` from GitHub Actions.
 
 ## What Stays Manual
 
 1. Create/verify your AUR account (email verification step in AUR UI).
-2. Create the `dwellir-bin` package repository on AUR (first-time package submission).
+2. Create the `dwellir-cli-bin` package repository on AUR (first-time package submission).
 3. Add your AUR SSH public key in AUR account settings.
 
 After this one-time setup, releases can be automatic via CI.
@@ -40,10 +40,10 @@ Set repo secret directly from file (recommended):
 gh secret set AUR_SSH_PRIVATE_KEY --repo dwellir-public/cli < ~/.ssh/dwellir_aur_ci
 ```
 
-Optional package name variable (default is `dwellir-bin`):
+Optional package name variable (default is `dwellir-cli-bin`):
 
 ```bash
-gh variable set AUR_PACKAGE_NAME --repo dwellir-public/cli --body "dwellir-bin"
+gh variable set AUR_PACKAGE_NAME --repo dwellir-public/cli --body "dwellir-cli-bin"
 ```
 
 ## 4. Verify SSH Access Without Leaking Secrets

--- a/packaging/aur/PKGBUILD.tmpl
+++ b/packaging/aur/PKGBUILD.tmpl
@@ -1,12 +1,12 @@
-pkgname=dwellir-bin
+pkgname=dwellir-cli-bin
 pkgver=__VERSION__
 pkgrel=1
 pkgdesc="Dwellir CLI - Blockchain RPC infrastructure from your terminal"
 arch=('x86_64' 'aarch64')
 url="https://github.com/dwellir-public/cli"
 license=('MIT')
-provides=('dwellir')
-conflicts=('dwellir')
+provides=('dwellir-cli')
+conflicts=('dwellir-cli')
 
 source_x86_64=("dwellir-linux-amd64-${pkgver}.tar.gz::https://github.com/dwellir-public/cli/releases/download/v${pkgver}/dwellir_linux_amd64.tar.gz")
 source_aarch64=("dwellir-linux-arm64-${pkgver}.tar.gz::https://github.com/dwellir-public/cli/releases/download/v${pkgver}/dwellir_linux_arm64.tar.gz")


### PR DESCRIPTION
## Summary
Rename the AUR package target from `dwellir-bin` to `dwellir-cli-bin` across automation and setup docs.

## Changes
- `.github/workflows/aur-release.yml`
  - default package name changed to `dwellir-cli-bin`
  - commit message now uses dynamic `${package_name}`
- `packaging/aur/PKGBUILD.tmpl`
  - `pkgname=dwellir-cli-bin`
  - `provides/conflicts` aligned to `dwellir-cli`
- `docs/aur-setup.md`
  - updated package name references and variable setup examples

## Validation
- `scripts/aur/render-pkgbuild.sh v0.1.2 /tmp/dwellir-cli-aur-pkgbuild`
- `go test ./...`
