### PR TITLE
[codex] Fix AUR workflow: run makepkg as non-root

### DIFF
--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -79,7 +79,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          docker run --rm -v "$PWD/dist/aur:/work" -w /work archlinux:latest bash -lc '
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$PWD/dist/aur:/work" \
+            -w /work \
+            archlinux:latest bash -lc '
             set -euo pipefail
             makepkg --printsrcinfo > .SRCINFO
             makepkg --verifysource --nobuild


### PR DESCRIPTION
## Summary
Fix AUR workflow failure caused by running `makepkg` as root inside the Arch container.

## Root cause
Arch `makepkg` explicitly refuses root execution. The previous workflow step used `docker run` default root user, so `.SRCINFO` generation and source verification failed.

## Change
- In `.github/workflows/aur-release.yml`, run the Arch container with:
  - `--user "$(id -u):$(id -g)"`

## Validation
- `go test ./...`
- confirmed failure mode from run `22455105131` logs (`makepkg as root is not allowed`).
