### PR TITLE
ci: right-size existing Blacksmith runners

### DIFF
--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -20,7 +20,7 @@ jobs:
   prepare:
     name: Prepare
     if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
@@ -73,7 +73,7 @@ jobs:
     name: Publish AUR
     needs: prepare
     if: ${{ needs.prepare.outputs.aur_configured == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       AUR_PACKAGE_NAME: ${{ vars.AUR_PACKAGE_NAME }}
     steps:
@@ -139,7 +139,7 @@ jobs:
     name: AUR Not Configured
     needs: prepare
     if: ${{ needs.prepare.outputs.aur_configured != 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Explain setup requirement
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   version-bump:
     name: version-bump
     if: github.event_name == 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -73,7 +73,7 @@ jobs:
 
   check:
     name: check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -86,7 +86,7 @@ jobs:
 
   build:
     name: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tag:
     name: tag-and-release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
This is a cleanup audit of the existing Blacksmith migration. The migration wizard put every workflow in this repo on `blacksmith-4vcpu-ubuntu-2404`; the audit shows these jobs are light enough that they should all run on `blacksmith-2vcpu-ubuntu-2404` instead.

## Why this change
Recent successful runs on the current `4vcpu` setup were all short:
- `CI` run `23649071777`
  - `build`: 19s
  - `check`: 36s
- `Tag Release` run `23649071785`
  - `tag-and-release`: 75s
- `AUR Release` run `23649131502`
  - `Prepare`: 6s
  - `Publish AUR`: 24s

Representative cost at current Blacksmith rates:
- `CI` sample: `55s` total runner time
  - `4vcpu`: about `$0.007/run`
  - `2vcpu`: about `$0.004/run`
- `Tag Release` sample: `75s`
  - `4vcpu`: about `$0.010/run`
  - `2vcpu`: about `$0.005/run`
- `AUR Release` sample: `30s`
  - `4vcpu`: about `$0.004/run`
  - `2vcpu`: about `$0.002/run`

So this repo is paying the `4vcpu` rate on jobs that are mostly release orchestration, linting, testing, and straightforward Go builds. There is no evidence in these runs that the extra cores are materially reducing wall time.

## Runner sizing rationale
- `ci.yml`
  - `version-bump`: `2vcpu`
  - `check`: `2vcpu`
  - `build`: `2vcpu`
  - These jobs are short and mostly single-process checks or straightforward Go work.
- `tag-release.yml`
  - `tag-and-release`: `2vcpu`
  - This job is mostly tagging, release checks, and goreleaser orchestration.
- `release.yml`
  - `release`: `2vcpu`
  - Similar reasoning: short-lived release packaging and publishing, not an obviously CPU-bound build.
- `aur-release.yml`
  - `Prepare`, `Publish AUR`, `AUR Not Configured`: `2vcpu`
  - These are setup/publish tasks, not compute-heavy workloads.

## Sticky disk audit
I also checked whether this repo should pay for Blacksmith sticky disks.
- Recommendation: `No`
- Reasoning:
  - Sticky disks cost `$0.50/GB/month` and are mainly worth it for very large dependency trees or caches where normal restore time is still a major bottleneck.
  - This repo's Go and release jobs are already very short.
  - Even if dependency caching were improved further, the first step would be standard free cache usage, not paid sticky disks.
  - There is not enough dependency restore time here to justify the add-on today.
